### PR TITLE
Add command line options for CSV input files which are passed along to Text::CSV

### DIFF
--- a/script/texttableutils-convert
+++ b/script/texttableutils-convert
@@ -17,6 +17,8 @@ my %Opts;
     Getopt::Long::GetOptions(
         "backend|b=s" => \$Opts{backend},
         "transpose|t" => \$Opts{transpose},
+        "csv-sep|s=s" => \$Opts{csv_sep},
+        "csv-loose|l" => \$Opts{csv_loose}
     ) or die "$0: Error in getting options, bailing out\n";
 }
 
@@ -40,6 +42,13 @@ my $rows;
         require Text::CSV;
         my $csv = Text::CSV->new({ binary => 1 })
             or die "Cannot use CSV: ".Text::CSV->error_diag;
+        if ($Opts{csv_sep}) {
+            $csv->sep($Opts{csv_sep});
+        }
+        if ($Opts{csv_loose}) {
+            $csv->allow_loose_quotes(1);
+            $csv->allow_loose_escapes(1);
+        }
         $rows = [];
         while ( my $row = $csv->getline($fh) ) {
             push @$rows, $row;
@@ -198,6 +207,15 @@ Select L<Text::Table::Any> backend to use.
 
 Transpose table prior to output.
 
+=head2 --csv-sep (-s)
+
+Use the character(s) specified by this option, when input is a CSV files with a
+different separator.
+
+=head2 --csv-loose (-l)
+
+Enable C<allow_loose_escapes> and C<allow_loose_quotes> in L<Text::CSV> (the
+backend used to read CSV files).
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Since not all CSV files are created equal, options to treat different CSV files differently are necessary :wink:

The two new options allow to specify the separator character(s) in the CSV
file (--csv-sep ";", -s) and to relax the CSV parsing (--csv-loose, -l).

This calls the Text::CSV methods `sep()` as well as `allow_loose_quotes()` and `allow_loose_escapes()`.
Example:
```
csv2json --csv-sep ";" --csv-loose input.csv > output.json
```